### PR TITLE
Let mock chroot use space from duffy host in rpmbuild

### DIFF
--- a/config/Dockerfiles/rpmbuild/Dockerfile
+++ b/config/Dockerfiles/rpmbuild/Dockerfile
@@ -29,6 +29,8 @@ RUN dnf -y install ansible \
 # Change some mock settings
 RUN echo "config_opts['package_manager'] = 'dnf'" >> /etc/mock/site-defaults.cfg
 RUN echo "config_opts['plugin_conf']['lvm_root_opts']['size'] = '16G'" >> /etc/mock/site-defaults.cfg
+RUN echo "config_opts['plugin_conf']['lvm_root_opts']['poolmetadatasize'] = '30G'" >> /etc/mock/site-defaults.cfg
+RUN echo "config_opts['basedir'] = '/home/rpmbuild/'" >> /etc/mock/site-defaults.cfg
 
 # Copy the build script to the container
 COPY rpmbuild-test.sh /home/rpmbuild-test.sh

--- a/tasks/rpmbuild-test
+++ b/tasks/rpmbuild-test
@@ -4,13 +4,15 @@ set +e
 HOMEDIR=$(pwd)
 rm -rf ${HOMEDIR}/${fed_repo}/output
 mkdir -p ${HOMEDIR}/${fed_repo}/output
+rm -rf ${HOMEDIR}/${fed_repo}/rpmbuild
+mkdir -p ${HOMEDIR}/${fed_repo}/rpmbuild
 pushd aos-ci/config/Dockerfiles/rpmbuild
 # Install docker
 which docker
 if [ "$?" != 0 ]; then echo "ERROR: DOCKER NOT INSTALLED\nSTATUS: $?"; exit 1; fi
 # Only build if it is not built already
 if [ "$(docker ps -a | grep rpmbuild-container)" == "" ]; then sudo docker build -t rpmbuild-container . ; fi
-sudo docker run --privileged --cap-add=SYS_ADMIN -v ${HOMEDIR}/${fed_repo}/output:/home/${fed_repo}/output -t -i -e fed_repo="${fed_repo}" -e fed_branch="${fed_branch}" -e fed_rev="${fed_rev}" rpmbuild-container
+sudo docker run --privileged --cap-add=SYS_ADMIN -v ${HOMEDIR}/${fed_repo}/output:/home/${fed_repo}/output -v ${HOMEDIR}/${fed_repo}/rpmbuild:/home/rpmbuild -t -i -e fed_repo="${fed_repo}" -e fed_branch="${fed_branch}" -e fed_rev="${fed_rev}" rpmbuild-container
 popd
 # Find out RSYNC_BRANCH name so we can rsync over an empty repo if it DNE
 RSYNC_BRANCH=$(echo ${fed_branch} | sed 's/./&c/1')


### PR DESCRIPTION
This PR mounts a directory from the duffy host inside of the fedora container that does the fedpkg mockbuild. 
It also adds config options to use that space as the directory for the mockbuild so that it does not run out of disk space when building the kernel package.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>