### PR TITLE
Copy make test output to a file

### DIFF
--- a/config/Dockerfiles/rpmbuild/rpmbuild-test.sh
+++ b/config/Dockerfiles/rpmbuild/rpmbuild-test.sh
@@ -30,7 +30,7 @@ pushd $DIR_TO_GO
 # Run configure if it exists, if not, no big deal
 ./configure
 # Run tests if they are there
-make test
+make test >> ${OUTPUTDIR}/logs/make_test_output.txt
 MAKE_TEST_STATUS=$?
 popd
 if [ "$MAKE_TEST_STATUS" == 2 ]; then


### PR DESCRIPTION
The build description is set to change based on the make test return code, but since groovy isn't in the environment yet, there is nothing to show.  Also, probably best to have this as its own file anyway.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>